### PR TITLE
Adding code from module to setup challenge.

### DIFF
--- a/components/__tests__/icon-button.test.js
+++ b/components/__tests__/icon-button.test.js
@@ -11,8 +11,14 @@
  
  const user = userEvent.setup()
  
-describe('IconButton', () =>{
-     it('labels the button', () => {
 
-     })
- })
+describe('IconButton', () => {
+    it('labels the button', () => {
+    const textFixture = 'Send it!';
+    const { getByLabelText } = render(<IconButton name={textFixture} />);
+
+    const buttonText = getByLabelText(textFixture);
+
+    expect(buttonText).toBeInTheDocument();
+  })
+})


### PR DESCRIPTION
-> Automated Accessibility Testing
-> Unit Testing with Jest and Testing Library
-> Lesson 2

First challenge: 
"🛠 Challenge: Fix the Failing IconButton Label Test"

The challenge assumes this code is present to test the IconButton Label so you can fix the component code to be compliant.

I would like to note: the code I've pasted from the module uses `describe` and `it` rather than `xdescribe` and `xit`. However the former works fine while the latter, which is used in the `Icon.test.js` file, does not. So I left it consistent with the module, and the `presets-custom-amounts.test.js` file. 🍻